### PR TITLE
DO NOT MERGE - HTTP2 issues repro

### DIFF
--- a/lib/file_beam/application.ex
+++ b/lib/file_beam/application.ex
@@ -10,8 +10,8 @@ defmodule FileBeam.Application do
     secure_options = [
       port: secure_port(),
       certfile: certificate_path(),
-      keyfile: certificate_key_path(),
-      alpn_preferred_protocols: ["http/1.1"]
+      keyfile: certificate_key_path()
+      # alpn_preferred_protocols: ["http/1.1"]
     ]
 
     children = [

--- a/lib/file_beam/www.ex
+++ b/lib/file_beam/www.ex
@@ -41,8 +41,8 @@ defmodule FileBeam.WWW do
     stack =
       Raxx.Stack.new(
         [
-          {FileBeam.Middleware.ResponseCompression, []},
-          {FileBeam.Middleware.HttpsRedirect, []},
+          # {FileBeam.Middleware.ResponseCompression, []},
+          # {FileBeam.Middleware.HttpsRedirect, []},
           {Raxx.Static, @static_setup}
         ],
         {__MODULE__.Router, config}


### PR DESCRIPTION
To reproduce:

- start the app with `iex -S mix`
- open it with https on https://localhost:8443/
- in web developer tools make sure the requests are made with http2
- select a large file to be sent through. The issue doesn't happen straight away, only after it's been transferred for a while. A 1.6 GB file that I'm using seems to be causing it every time
- open the receive page in another tab and download it
- watch the application logs, you'll hopefully notice this

```
20:45:13.013 [debug] SERVER (port: 8443) received: DATA(stream_id: 37, end_stream: false, data: <<197, 220, 132, 237, 167, 13, 215, 60, 36, 205, 178, 219, 122, 191, 41, 153, 88, 45, 139, 106, 193, 96, 240, 187, 78, 223, 112, 226, 166, 235, 38, 110, 250, 98, 226, 192, 207, 40, 1, 105, 239, 165, 23, 28, 28, 92, 109, 176, 108, 47, ...>>...)
 
20:45:13.013 [debug] SERVER (port: 8443) sent: WINDOWN_UPDATE(stream_id: 0, increment: 65535)

20:45:13.013 [debug] SERVER (port: 8443) sent: WINDOWN_UPDATE(stream_id: 37, increment: 65535)
 
20:45:13.029 [error] GenServer #PID<0.557.0> terminating
** (MatchError) no match of right hand side value: {:error, :enotconn}
    (ace) lib/ace/http2/connection.ex:179: anonymous fn/3 in Ace.HTTP2.Connection.handle_call/3
    (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ace) lib/ace/http2/connection.ex:152: Ace.HTTP2.Connection.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message (from #PID<0.801.0>): {:send, %Ace.HTTP.Channel{endpoint: #PID<0.557.0>, id: 47, socket: :h2_socket}, [%Raxx.Data{data: <<229, 8, 229, 1, 193, 66, 31, 88, 88, 16, 69, 130, 213, 97, 53, 183, 43, 19, 204, 224, 206, 210, 13, 208, 140, 141, 187, 125, 147, 49, 236, 137, 194, 77, 180, 99, 119, 158, 198, 119, 229, 216, 87, 10, 174, ...>>}, %Raxx.Data{data: <<101, 26, 9, 252, 90, 157, 35, 45, 78, 122, 63, 32, 251, 167, 154, 93, 165, 166, 212, 141, 225, 107, 112, 36, 88, 163, 211, 49, 177, 187, 10, 201, 235, 39, 99, 11, 158, 225, 152, 214, 74, 236, 233, 205, ...>>}]}
State: {"", %Ace.HTTP2.Connection{decode_context: {:hpack_context, {:dynamic_table, [{62, "referer", "https://localhost:8443/receive/M1AqlXI5H8"}, {63, "content-length", "1600801373"}, {64, "x-original-filename", "sales_db_dump"}, {65, "accept", "image/webp,*/*"}, {66, "cache-control", "no-cache"}, {67, "pragma", "no-cache"}, {68, "accept", "text/event-stream"}, {69, "accept", "*/*"}, {70, "referer", "https://localhost:8443/"}, {71, "accept", "text/css,*/*;q=0.1"}, {72, "te", "trailers"}, {73, "upgrade-insecure-requests", "1"}, {74, "cookie", "_wobserver=12f06f584156afc004b56419851a9dad1d3e00e4079d01593e1e5710f0e2d342"}, {75, "cookie", "mr_b_token=677a6ffa-df47-47b7-b2ad-3c5ac2cd4ae7"}, {76, "cookie", "_chat_key=SFMyNTY.g3QAAAABbQAAAAtfY3NyZl90b2tlbm0AAAAYWUk0WWxZd0t3bzJRMzcwX2ZpM1hHb19R.gCg5GKzOGhFGKW-Flt-MXb4JOPPkMVKd0EjkmCYPnH8"}, {77, "dnt", "1"}, {78, "accept-encoding", "gzip, deflate, br"}, {79, "accept-language", "en-US,en;q=0.5"}, {80, "accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}, {81, "user-agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:67.0) Gecko/20100101 Firefox/67.0"}, {82, ":authority", "localhost:8443"}], 4096, 1467}, 4096}, encode_context: {:hpack_context, {:dynamic_table, [{62, "content-length", "1600801373"}, {63, "content-disposition", "attachment; filename=\"sales_db_dump\""}, {64, "content-length", "3254"}, {65, "content-length", "32038"}, {66, "content-type", "image/vnd.microsoft.icon"}, {67, "content-type", "text/event-stream"}, {68, "content-length", "88145"}, {69, "content-length", "1045"}, {70, "content-type", "application/javascript"}, {71, "content-length", "66"}, {72, "content-type", "text/css"}, {73, "content-length", "4690"}, {74, "content-type", "text/html"}], 4096, 743}, 4096}, local_settings: %Ace.HTTP2.Settings{enable_push: false, initial_window_size: 65535, max_concurrent_streams: 10000, max_frame_size: 16384}, max_peer_stream_id: 47, name: "SERVER (port: 8443)", next: :any, next_local_stream_id: 2, outbound_window: 0, peer: :server, pings: %{}, queued_settings: [], remote_settings: %Ace.HTTP2.Settings{enable_push: true, initial_window_size: 131072, max_concurrent_streams: 10000, max_frame_size: 16384}, socket: {:ssl, {:sslsocket, {:gen_tcp, #Port<0.63>, :tls_connection, #PID<0.532.0>}, [#PID<0.783.0>, #PID<0.782.0>]}}, stream_supervisor: #PID<0.533.0>, streams: %{15 => %Ace.HTTP2.Stream{id: 15, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3995860996.248955>, queue: [], sent: 4690, status: {:closed, :closed}, worker: #PID<0.784.0>}, 17 => %Ace.HTTP2.Stream{id: 17, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3995860996.248981>, queue: [], sent: 66, status: {:closed, :closed}, worker: #PID<0.785.0>}, 19 => %Ace.HTTP2.Stream{id: 19, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3995860993.253624>, queue: [], sent: 1045, status: {:closed, :closed}, worker: #PID<0.786.0>}, 21 => %Ace.HTTP2.Stream{id: 21, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3995860993.253633>, queue: [], sent: 88145, status: {:closed, :closed}, worker: #PID<0.787.0>}, 23 => %Ace.HTTP2.Stream{id: 23, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3995860993.253654>, queue: [], sent: 0, status: {:closed, :closed}, worker: #PID<0.788.0>}, 25 => %Ace.HTTP2.Stream{id: 25, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3995860993.253744>, queue: [], sent: 4690, status: {:closed, :closed}, worker: #PID<0.789.0>}, 27 => %Ace.HTTP2.Stream{id: 27, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3995860995.248914>, queue: [], sent: 66, status: {:closed, :closed}, worker: #PID<0.790.0>}, 29 => %Ace.HTTP2.Stream{id: 29, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3995860996.249164>, queue: [], sent: 1045, status: {:closed, :closed}, worker: #PID<0.791.0>}, 31 => %Ace.HTTP2.Stream{id: 31, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3995860993.253773>, queue: [], sent: 88145, status: {:closed, :closed}, worker: #PID<0.792.0>}, 33 => %Ace.HTTP2.Stream{id: 33, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3995860995.249044>, queue: [%Raxx.Data{data: "data: {\"bytes_transferred\":417159171,\"current_speed\":5650496.0,\"file_size\":1600801373,\"filename\":\"sales_db_dump\",\"progress\":0.2605939612721709}\n\n"}], sent: 8589, status: {:open, :closed}, worker: #PID<0.793.0>}, 35 => %Ace.HTTP2.Stream{id: 35, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3995860993.253861>, queue: [], sent: 32038, status: {:closed, :closed}, worker: #PID<0.794.0>}, 37 => %Ace.HTTP2.Stream{id: 37, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3995860993.253945>, queue: [], sent: 0, status: {:idle, :open}, worker: #PID<0.795.0>}, 39 => %Ace.HTTP2.Stream{id: 39, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3996123137.20662>, queue: [], sent: 3254, status: {:closed, :closed}, worker: #PID<0.797.0>}, 41 => %Ace.HTTP2.Stream{id: 41, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3996123138.23445>, queue: [], sent: 66, status: {:closed, :closed}, worker: #PID<0.798.0>}, 43 => %Ace.HTTP2.Stream{id: 43, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3996123137.25432>, queue: [], sent: 1045, status: {:closed, :closed}, worker: #PID<0.799.0>}, 45 => %Ace.HTTP2.Stream{id: 45, incremented: 12451840, initial_window_size: 131072, monitor: #Reference<0.2384028630.3996123137.27700>, queue: [%Raxx.Data{data: "data: {\"bytes_transferred\":418445939,\"current_speed\":6192416.0,\"file_size\":1600801373,\"filename\":\"sales_db_dump\",\"progress\":0.26139778866868824}\n\n"}], sent: 6971, status: {:open, :closed}, worker: #PID<0.800.0>}, 47 => %Ace.HTTP2.Stream{id: 47, incremented: 155090275, initial_window_size: 131072, monitor: #Reference<0.2384028630.3996123138.32685>, queue: [%Raxx.Data{data: <<217, 163, 232, 75, 211, 156, 68, 62, 192, ...>>}, %Raxx.Data{data: <<104, 253, 92, 243, 22, 229, 124, 10, ...>>}, %Raxx.Data{data: <<96, 129, 151, 44, 77, 180, 69, ...>>}, %Raxx.Data{data: <<7, 168, 147, 215, 4, 153, ...>>}, %Raxx.Data{data: <<122, 236, 149, 178, 234, ...>>}, %Raxx.Data{data: <<198, 36, 88, 93, ...>>}, %Raxx.Data{data: <<24, 74, 94, ...>>}, %Raxx.Data{data: <<3, 94, ...>>}, %Raxx.Data{data: <<86, ...>>}, %Raxx.Data{data: <<...>>}, %Raxx.Data{...}, ...], sent: 154991389, status: {:open, :closed}, worker: #PID<0.801.0>}}}}
Client #PID<0.801.0> is alive

    (stdlib) gen.erl:1 (truncated)
 
20:45:13.036 [error] GenServer #PID<0.557.0> terminating
** (MatchError) no match of right hand side value: {:error, :enotconn}
    (ace) lib/ace/http2/connection.ex:179: anonymous fn/3 in Ace.HTTP2.Connection.handle_call/3
    (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ace) lib/ace/http2/connection.ex:152: Ace.HTTP2.Connection.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message (from #PID<0.556.0>): {:accept, {:ssl, {:sslsocket, nil, {#Port<0.52>, {:config, {:ssl_options, :tls, [{3, 3}], :verify_none, {#Function<8.60207287/3 in :ssl.handle_verify_options/2>, []}, #Function<9.60207287/1 in :ssl.handle_verify_options/2>, false, false, :undefined, 1, "/home/nietaki/repos/file_beam/_build/dev/lib/file_beam/priv/localhost/certificate.pem", :undefined, "/home/nietaki/repos/file_beam/_build/dev/lib/file_beam/priv/localhost/certificate_key.pem", :undefined, [], :undefined, "", :undefined, :undefined, :undefined, :undefined, :undefined, [<<192, 44>>, <<192, 48>>, <<192, 36>>, <<192, 40>>, <<192, 46>>, <<192, 50>>, <<192, 38>>, <<192, 42>>, <<0, 159>>, <<0, 163>>, <<0, 107>>, <<0, 106>>, <<192, 43>>, <<192, 47>>, <<192, ...>>, <<...>>, ...], #Function<4.60207287/4 in :ssl.handle_reuse_session_option/3>, true, 268435456, true, true, :infinity, false, :undefined, ["h2", "http/1.1"], :undefined, :undefined, :notice, :undefined, [], :undefined, false, ...}, [send_timeout_close: true, send_timeout: 10000, reuseaddr: true, packet_size: 0, packet: 0, header: 0, active: false, mode: :binary], #PID<0.532.0>, :undefined, [send_timeout_close: true, send_timeout: 10000, reuseaddr: true, packet_size: 0, packet: 0, header: 0, active: false, mode: :binary], {:gen_tcp, :tcp, :tcp_closed, :tcp_error, :tcp_passive}, :tls_connection}}}}}
State: %Ace.HTTP.Server{settings: [port: 8443, certfile: "/home/nietaki/repos/file_beam/_build/dev/lib/file_beam/priv/localhost/certificate.pem", keyfile: "/home/nietaki/repos/file_beam/_build/dev/lib/file_beam/priv/localhost/certificate_key.pem"], socket: nil, worker_supervisor: #PID<0.533.0>}
Client #PID<0.556.0> is alive

    (stdlib) gen_server.erl:394: :gen_server.loop/7
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
 
20:45:13.041 [error] GenServer #PID<0.801.0> terminating
** (stop) exited in: GenServer.call(#PID<0.557.0>, {:send, %Ace.HTTP.Channel{endpoint: #PID<0.557.0>, id: 47, socket: :h2_socket}, [%Raxx.Data{data: <<229, 8, 229, 1, 193, 66, 31, 88, 88, 16, 69, 130, 213, 97, 53, 183, 43, 19, 204, 224, 206, 210, 13, 208, 140, 141, 187, 125, 147, 49, 236, 137, 194, 77, 180, 99, 119, 158, 198, 119, 229, 216, 87, 10, 174, ...>>}, %Raxx.Data{data: <<101, 26, 9, 252, 90, 157, 35, 45, 78, 122, 63, 32, 251, 167, 154, 93, 165, 166, 212, 141, 225, 107, 112, 36, 88, 163, 211, 49, 177, 187, 10, 201, 235, 39, 99, 11, 158, 225, 152, 214, 74, 236, 233, 205, ...>>}]}, 5000)
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: {:error, :enotconn}
            (ace) lib/ace/http2/connection.ex:179: anonymous fn/3 in Ace.HTTP2.Connection.handle_call/3
            (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
            (ace) lib/ace/http2/connection.ex:152: Ace.HTTP2.Connection.handle_call/3
            (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
            (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
            (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
            (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
            (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
    (elixir) lib/gen_server.ex:989: GenServer.call/3
    (ace) lib/ace/http/channel.ex:48: Ace.HTTP.Channel.send/2
    (ace) lib/ace/http/worker.ex:82: Ace.HTTP.Worker.do_send/2
    (stdlib) gen_server.erl:637: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:711: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: :more
State: %Ace.HTTP.Worker{app_module: Raxx.Stack, app_state: %Raxx.Stack.State{middlewares: [{Raxx.Static, [source: "/home/nietaki/repos/file_beam/lib/file_beam/www/public"]}], server: {FileBeam.WWW.Router, {Raxx.Stack, %Raxx.Stack.State{middlewares: [{Raxx.Logger, %Raxx.Logger{level: :info, request: %Raxx.Request{authority: "localhost:8443", body: false, headers: [{"user-agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:67.0) Gecko/20100101 Firefox/67.0"}, {"accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}, {"accept-language", "en-US,en;q=0.5"}, {"accept-encoding", "gzip, deflate, br"}, {"referer", "https://localhost:8443/receive/M1AqlXI5H8"}, {"dnt", "1"}, {"cookie", "_chat_key=SFMyNTY.g3QAAAABbQAAAAtfY3NyZl90b2tlbm0AAAAYWUk0WWxZd0t3bzJRMzcwX2ZpM1hHb19R.gCg5GKzOGhFGKW-Flt-MXb4JOPPkMVKd0EjkmCYPnH8"}, {"cookie", "mr_b_token=677a6ffa-df47-47b7-b2ad-3c5ac2cd4ae7"}, {"cookie", "_wobserver=12f06f584156afc004b56419851a9dad1d3e00e4079d01593e1e5710f0e2d342"}, {"upgrade-insecure-requests", "1"}, {"te", "trailers"}], method: :GET, path: ["download", "M1AqlXI5H8"], query: nil, raw_path: "/download/M1AqlXI5H8", scheme: :https}, start: -576460713282481856}}], server: {FileBeam.WWW.Actions.Download, %FileBeam.WWW.Actions.Download{buffer_pid: #PID<0.796.0>}}}}}}, channel: %Ace.HTTP.Channel{endpoint: #PID<0.557.0>, id: 47, socket: :h2_socket}, channel_monitor: #Reference<0.2384028630.3996123139.28407>}
 
20:45:13.042 [error] GenServer #PID<0.795.0> terminating
** (MatchError) no match of right hand side value: {:error, :enotconn}
    (ace) lib/ace/http2/connection.ex:179: anonymous fn/3 in Ace.HTTP2.Connection.handle_call/3
    (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ace) lib/ace/http2/connection.ex:152: Ace.HTTP2.Connection.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:DOWN, #Reference<0.2384028630.3995860993.253944>, :process, #PID<0.557.0>, {{:badmatch, {:error, :enotconn}}, [{Ace.HTTP2.Connection, :"-handle_call/3-fun-0-", 3, [file: 'lib/ace/http2/connection.ex', line: 179]}, {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: 'lib/enum.ex', line: 1940]}, {Ace.HTTP2.Connection, :handle_call, 3, [file: 'lib/ace/http2/connection.ex', line: 152]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}}
State: %Ace.HTTP.Worker{app_module: Raxx.Stack, app_state: %Raxx.Stack.State{middlewares: [{Raxx.Static, [source: "/home/nietaki/repos/file_beam/lib/file_beam/www/public"]}], server: {FileBeam.WWW.Router, {Raxx.Stack, %Raxx.Stack.State{middlewares: [{Raxx.Logger, %Raxx.Logger{level: :info, request: %Raxx.Request{authority: "localhost:8443", body: true, headers: [{"user-agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:67.0) Gecko/20100101 Firefox/67.0"}, {"accept", "*/*"}, {"accept-language", "en-US,en;q=0.5"}, {"accept-encoding", "gzip, deflate, br"}, {"referer", "https://localhost:8443/"}, {"x-original-filename", "sales_db_dump"}, {"content-length", "1600801373"}, {"dnt", "1"}, {"cookie", "_chat_key=SFMyNTY.g3QAAAABbQAAAAtfY3NyZl90b2tlbm0AAAAYWUk0WWxZd0t3bzJRMzcwX2ZpM1hHb19R.gCg5GKzOGhFGKW-Flt-MXb4JOPPkMVKd0EjkmCYPnH8"}, {"cookie", "mr_b_token=677a6ffa-df47-47b7-b2ad-3c5ac2cd4ae7"}, {"cookie", "_wobserver=12f06f584156afc004b56419851a9dad1d3e00e4079d01593e1e5710f0e2d342"}, {"pragma", "no-cache"}, {"cache-control", "no-cache"}, {"te", "trailers"}], method: :POST, path: ["upload", "M1AqlXI5H8"], query: nil, raw_path: "/upload/M1AqlXI5H8", scheme: :https}, start: -576460721975302958}}], server: {FileBeam.WWW.Actions.Upload, %FileBeam.WWW.Actions.Upload{buffer_pid: #PID<0.796.0>}}}}}}, channel: %Ace.HTTP.Channel{endpoint: #PID<0.557.0>, id: 37, socket: :h2_socket}, channel_monitor: #Reference<0.2384028630.3995860993.253944>}
 
20:45:13.043 [info]  FileBuffer server got info: {:DOWN, #Reference<0.2384028630.3995860993.253990>, :process, #PID<0.795.0>, {{:badmatch, {:error, :enotconn}}, [{Ace.HTTP2.Connection, :"-handle_call/3-fun-0-", 3, [file: 'lib/ace/http2/connection.ex', line: 179]}, {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: 'lib/enum.ex', line: 1940]}, {Ace.HTTP2.Connection, :handle_call, 3, [file: 'lib/ace/http2/connection.ex', line: 152]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}}
 
20:45:13.046 [error] GenServer #PID<0.789.0> terminating
** (MatchError) no match of right hand side value: {:error, :enotconn}
    (ace) lib/ace/http2/connection.ex:179: anonymous fn/3 in Ace.HTTP2.Connection.handle_call/3
    (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ace) lib/ace/http2/connection.ex:152: Ace.HTTP2.Connection.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:DOWN, #Reference<0.2384028630.3995860993.253743>, :process, #PID<0.557.0>, {{:badmatch, {:error, :enotconn}}, [{Ace.HTTP2.Connection, :"-handle_call/3-fun-0-", 3, [file: 'lib/ace/http2/connection.ex', line: 179]}, {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: 'lib/enum.ex', line: 1940]}, {Ace.HTTP2.Connection, :handle_call, 3, [file: 'lib/ace/http2/connection.ex', line: 152]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}}
State: %Ace.HTTP.Worker{app_module: Raxx.Stack, app_state: %Raxx.Stack.State{middlewares: [{Raxx.Static, [source: "/home/nietaki/repos/file_beam/lib/file_beam/www/public"]}], server: {FileBeam.WWW.Router, {Raxx.Stack, %Raxx.Stack.State{middlewares: [{Raxx.Logger, %Raxx.Logger{level: :info, request: %Raxx.Request{authority: "localhost:8443", body: false, headers: [{"user-agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:67.0) Gecko/20100101 Firefox/67.0"}, {"accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}, {"accept-language", "en-US,en;q=0.5"}, {"accept-encoding", "gzip, deflate, br"}, {"dnt", "1"}, {"cookie", "_chat_key=SFMyNTY.g3QAAAABbQAAAAtfY3NyZl90b2tlbm0AAAAYWUk0WWxZd0t3bzJRMzcwX2ZpM1hHb19R.gCg5GKzOGhFGKW-Flt-MXb4JOPPkMVKd0EjkmCYPnH8"}, {"cookie", "mr_b_token=677a6ffa-df47-47b7-b2ad-3c5ac2cd4ae7"}, {"cookie", "_wobserver=12f06f584156afc004b56419851a9dad1d3e00e4079d01593e1e5710f0e2d342"}, {"upgrade-insecure-requests", "1"}, {"pragma", "no-cache"}, {"cache-control", "no-cache"}, {"te", "trailers"}], method: :GET, path: [], query: nil, raw_path: "/", scheme: :https}, start: -576460729710071691}}], server: {FileBeam.WWW.Actions.HomePage, %{session_config: %Raxx.Session{cookie_options: [], key: "my_app_session", store: %Raxx.Session.SignedCookie{salt: "Z7v3J2", secret_key_base: "nA_9oYAwARXf_d9KqgWOYdCUWlTlFeFfguhTiiwVy7eUNTqj9f7PUdv1fHVnk9sq"}}}}}}}}, channel: %Ace.HTTP.Channel{endpoint: #PID<0.557.0>, id: 25, socket: :h2_socket}, channel_monitor: #Reference<0.2384028630.3995860993.253743>}
 
20:45:13.047 [error] GenServer #PID<0.797.0> terminating
** (MatchError) no match of right hand side value: {:error, :enotconn}
    (ace) lib/ace/http2/connection.ex:179: anonymous fn/3 in Ace.HTTP2.Connection.handle_call/3
    (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ace) lib/ace/http2/connection.ex:152: Ace.HTTP2.Connection.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:DOWN, #Reference<0.2384028630.3996123137.20661>, :process, #PID<0.557.0>, {{:badmatch, {:error, :enotconn}}, [{Ace.HTTP2.Connection, :"-handle_call/3-fun-0-", 3, [file: 'lib/ace/http2/connection.ex', line: 179]}, {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: 'lib/enum.ex', line: 1940]}, {Ace.HTTP2.Connection, :handle_call, 3, [file: 'lib/ace/http2/connection.ex', line: 152]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}}
State: %Ace.HTTP.Worker{app_module: Raxx.Stack, app_state: %Raxx.Stack.State{middlewares: [{Raxx.Static, [source: "/home/nietaki/repos/file_beam/lib/file_beam/www/public"]}], server: {FileBeam.WWW.Router, {Raxx.Stack, %Raxx.Stack.State{middlewares: [{Raxx.Logger, %Raxx.Logger{level: :info, request: %Raxx.Request{authority: "localhost:8443", body: false, headers: [{"user-agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:67.0) Gecko/20100101 Firefox/67.0"}, {"accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}, {"accept-language", "en-US,en;q=0.5"}, {"accept-encoding", "gzip, deflate, br"}, {"dnt", "1"}, {"cookie", "_chat_key=SFMyNTY.g3QAAAABbQAAAAtfY3NyZl90b2tlbm0AAAAYWUk0WWxZd0t3bzJRMzcwX2ZpM1hHb19R.gCg5GKzOGhFGKW-Flt-MXb4JOPPkMVKd0EjkmCYPnH8"}, {"cookie", "mr_b_token=677a6ffa-df47-47b7-b2ad-3c5ac2cd4ae7"}, {"cookie", "_wobserver=12f06f584156afc004b56419851a9dad1d3e00e4079d01593e1e5710f0e2d342"}, {"upgrade-insecure-requests", "1"}, {"te", "trailers"}], method: :GET, path: ["receive", "M1AqlXI5H8"], query: nil, raw_path: "/receive/M1AqlXI5H8", scheme: :https}, start: -576460716465179098}}], server: {FileBeam.WWW.Actions.Receive, %{session_config: %Raxx.Session{cookie_options: [], key: "my_app_session", store: %Raxx.Session.SignedCookie{salt: "Z7v3J2", secret_key_base: "nA_9oYAwARXf_d9KqgWOYdCUWlTlFeFfguhTiiwVy7eUNTqj9f7PUdv1fHVnk9sq"}}}}}}}}, channel: %Ace.HTTP.Channel{endpoint: #PID<0.557.0>, id: 39, socket: :h2_socket}, channel_monitor: #Reference<0.2384028630.3996123137.20661>}

20:45:13.048 [error] GenServer #PID<0.784.0> terminating
** (MatchError) no match of right hand side value: {:error, :enotconn}
    (ace) lib/ace/http2/connection.ex:179: anonymous fn/3 in Ace.HTTP2.Connection.handle_call/3
    (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ace) lib/ace/http2/connection.ex:152: Ace.HTTP2.Connection.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:DOWN, #Reference<0.2384028630.3995860996.248951>, :process, #PID<0.557.0>, {{:badmatch, {:error, :enotconn}}, [{Ace.HTTP2.Connection, :"-handle_call/3-fun-0-", 3, [file: 'lib/ace/http2/connection.ex', line: 179]}, {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: 'lib/enum.ex', line: 1940]}, {Ace.HTTP2.Connection, :handle_call, 3, [file: 'lib/ace/http2/connection.ex', line: 152]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}}
State: %Ace.HTTP.Worker{app_module: Raxx.Stack, app_state: %Raxx.Stack.State{middlewares: [{Raxx.Static, [source: "/home/nietaki/repos/file_beam/lib/file_beam/www/public"]}], server: {FileBeam.WWW.Router, {Raxx.Stack, %Raxx.Stack.State{middlewares: [{Raxx.Logger, %Raxx.Logger{level: :info, request: %Raxx.Request{authority: "localhost:8443", body: false, headers: [{"user-agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:67.0) Gecko/20100101 Firefox/67.0"}, {"accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"}, {"accept-language", "en-US,en;q=0.5"}, {"accept-encoding", "gzip, deflate, br"}, {"dnt", "1"}, {"cookie", "_chat_key=SFMyNTY.g3QAAAABbQAAAAtfY3NyZl90b2tlbm0AAAAYWUk0WWxZd0t3bzJRMzcwX2ZpM1hHb19R.gCg5GKzOGhFGKW-Flt-MXb4JOPPkMVKd0EjkmCYPnH8"}, {"cookie", "mr_b_token=677a6ffa-df47-47b7-b2ad-3c5ac2cd4ae7"}, {"cookie", "_wobserver=12f06f584156afc004b56419851a9dad1d3e00e4079d01593e1e5710f0e2d342"}, {"upgrade-insecure-requests", "1"}, {"te", "trailers"}], method: :GET, path: [], query: nil, raw_path: "/", scheme: :https}, start: -576460732142302916}}], server: {FileBeam.WWW.Actions.HomePage, %{session_config: %Raxx.Session{cookie_options: [], key: "my_app_session", store: %Raxx.Session.SignedCookie{salt: "Z7v3J2", secret_key_base: "nA_9oYAwARXf_d9KqgWOYdCUWlTlFeFfguhTiiwVy7eUNTqj9f7PUdv1fHVnk9sq"}}}}}}}}, channel: %Ace.HTTP.Channel{endpoint: #PID<0.557.0>, id: 15, socket: :h2_socket}, channel_monitor: #Reference<0.2384028630.3995860996.248951>}
 
20:45:13.062 [error] GenServer #PID<0.793.0> terminating
** (MatchError) no match of right hand side value: {:error, :enotconn}
    (ace) lib/ace/http2/connection.ex:179: anonymous fn/3 in Ace.HTTP2.Connection.handle_call/3
    (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ace) lib/ace/http2/connection.ex:152: Ace.HTTP2.Connection.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:DOWN, #Reference<0.2384028630.3995860995.249043>, :process, #PID<0.557.0>, {{:badmatch, {:error, :enotconn}}, [{Ace.HTTP2.Connection, :"-handle_call/3-fun-0-", 3, [file: 'lib/ace/http2/connection.ex', line: 179]}, {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: 'lib/enum.ex', line: 1940]}, {Ace.HTTP2.Connection, :handle_call, 3, [file: 'lib/ace/http2/connection.ex', line: 152]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}}
State: %Ace.HTTP.Worker{app_module: Raxx.Stack, app_state: %Raxx.Stack.State{middlewares: [{Raxx.Static, [source: "/home/nietaki/repos/file_beam/lib/file_beam/www/public"]}], server: {FileBeam.WWW.Router, {Raxx.Stack, %Raxx.Stack.State{middlewares: [{Raxx.Logger, %Raxx.Logger{level: :info, request: %Raxx.Request{authority: "localhost:8443", body: false, headers: [{"user-agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:67.0) Gecko/20100101 Firefox/67.0"}, {"accept", "text/event-stream"}, {"accept-language", "en-US,en;q=0.5"}, {"accept-encoding", "gzip, deflate, br"}, {"referer", "https://localhost:8443/"}, {"dnt", "1"}, {"cookie", "_chat_key=SFMyNTY.g3QAAAABbQAAAAtfY3NyZl90b2tlbm0AAAAYWUk0WWxZd0t3bzJRMzcwX2ZpM1hHb19R.gCg5GKzOGhFGKW-Flt-MXb4JOPPkMVKd0EjkmCYPnH8"}, {"cookie", "mr_b_token=677a6ffa-df47-47b7-b2ad-3c5ac2cd4ae7"}, {"cookie", "_wobserver=12f06f584156afc004b56419851a9dad1d3e00e4079d01593e1e5710f0e2d342"}, {"pragma", "no-cache"}, {"cache-control", "no-cache"}, {"te", "trailers"}], method: :GET, path: ["stats_sse", "M1AqlXI5H8"], query: nil, raw_path: "/stats_sse/M1AqlXI5H8", scheme: :https}, start: -576460729207617323}}], server: {FileBeam.WWW.Actions.StatsSSE, %FileBeam.WWW.Actions.StatsSSE{buid: "M1AqlXI5H8", metadata: %{content_length: 1600801373, original_content_type: nil, original_filename: "sales_db_dump"}, stats: %FileBeam.Core.FileBuffer.Stats{bytes_transferred: 417159171, download_started_at: #DateTime<2019-08-26 19:44:49.604455Z>, upload_started_at: #DateTime<2019-08-26 19:44:40.926434Z>}}}}}}}, channel: %Ace.HTTP.Channel{endpoint: #PID<0.557.0>, id: 33, socket: :h2_socket}, channel_monitor: #Reference<0.2384028630.3995860995.249043>}
 
20:45:13.063 [error] GenServer #PID<0.800.0> terminating
** (MatchError) no match of right hand side value: {:error, :enotconn}
    (ace) lib/ace/http2/connection.ex:179: anonymous fn/3 in Ace.HTTP2.Connection.handle_call/3
    (elixir) lib/enum.ex:1940: Enum."-reduce/3-lists^foldl/2-0-"/3
    (ace) lib/ace/http2/connection.ex:152: Ace.HTTP2.Connection.handle_call/3
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) gen_server.erl:661: :gen_server.try_handle_call/4
    (stdlib) gen_server.erl:690: :gen_server.handle_msg/6
    (stdlib) proc_lib.erl:249: :proc_lib.init_p_do_apply/3
Last message: {:DOWN, #Reference<0.2384028630.3996123138.25696>, :process, #PID<0.557.0>, {{:badmatch, {:error, :enotconn}}, [{Ace.HTTP2.Connection, :"-handle_call/3-fun-0-", 3, [file: 'lib/ace/http2/connection.ex', line: 179]}, {Enum, :"-reduce/3-lists^foldl/2-0-", 3, [file: 'lib/enum.ex', line: 1940]}, {Ace.HTTP2.Connection, :handle_call, 3, [file: 'lib/ace/http2/connection.ex', line: 152]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:gen_server, :try_handle_call, 4, [file: 'gen_server.erl', line: 661]}, {:gen_server, :handle_msg, 6, [file: 'gen_server.erl', line: 690]}, {:proc_lib, :init_p_do_apply, 3, [file: 'proc_lib.erl', line: 249]}]}}
State: %Ace.HTTP.Worker{app_module: Raxx.Stack, app_state: %Raxx.Stack.State{middlewares: [{Raxx.Static, [source: "/home/nietaki/repos/file_beam/lib/file_beam/www/public"]}], server: {FileBeam.WWW.Router, {Raxx.Stack, %Raxx.Stack.State{middlewares: [{Raxx.Logger, %Raxx.Logger{level: :info, request: %Raxx.Request{authority: "localhost:8443", body: false, headers: [{"user-agent", "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:67.0) Gecko/20100101 Firefox/67.0"}, {"accept", "text/event-stream"}, {"accept-language", "en-US,en;q=0.5"}, {"accept-encoding", "gzip, deflate, br"}, {"referer", "https://localhost:8443/receive/M1AqlXI5H8"}, {"dnt", "1"}, {"cookie", "_chat_key=SFMyNTY.g3QAAAABbQAAAAtfY3NyZl90b2tlbm0AAAAYWUk0WWxZd0t3bzJRMzcwX2ZpM1hHb19R.gCg5GKzOGhFGKW-Flt-MXb4JOPPkMVKd0EjkmCYPnH8"}, {"cookie", "mr_b_token=677a6ffa-df47-47b7-b2ad-3c5ac2cd4ae7"}, {"cookie", "_wobserver=12f06f584156afc004b56419851a9dad1d3e00e4079d01593e1e5710f0e2d342"}, {"pragma", "no-cache"}, {"cache-control", "no-cache"}, {"te", "trailers"}], method: :GET, path: ["stats_sse", "M1AqlXI5H8"], query: nil, raw_path: "/stats_sse/M1AqlXI5H8", scheme: :https}, start: -576460715008841753}}], server: {FileBeam.WWW.Actions.StatsSSE, %FileBeam.WWW.Actions.StatsSSE{buid: "M1AqlXI5H8", metadata: %{content_length: 1600801373, original_content_type: nil, original_filename: "sales_db_dump"}, stats: %FileBeam.Core.FileBuffer.Stats{bytes_transferred: 418445939, download_started_at: #DateTime<2019-08-26 19:44:49.604455Z>, upload_started_at: #DateTime<2019-08-26 19:44:40.926434Z>}}}}}}}, channel: %Ace.HTTP.Channel{endpoint: #PID<0.557.0>, id: 45, socket: :h2_socket}, channel_monitor: #Reference<0.2384028630.3996123138.25696>}
```

It never seems to happen with http 1.1